### PR TITLE
Search, Call to Action, Modals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ lib/
 p2plending/frontend/node_modules/
 p2plending/frontend/dist/main.js
 venv/
+.env
 
 .DS_Store

--- a/p2plending/frontend/package-lock.json
+++ b/p2plending/frontend/package-lock.json
@@ -898,6 +898,12 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI=",
+      "dev": true
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -4646,6 +4652,25 @@
         }
       }
     },
+    "google-map-react": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/google-map-react/-/google-map-react-1.1.4.tgz",
+      "integrity": "sha512-+XcOu7QrRrlDa7Bk25oVV4FSsvMorAupuBrnDjA28Zz+HE+wEz79igqn+0KCHbemjgEHz51sHk0wm+IodvLoMg==",
+      "dev": true,
+      "requires": {
+        "@mapbox/point-geometry": "^0.1.0",
+        "eventemitter3": "^1.1.0",
+        "scriptjs": "^2.5.7"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+          "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
+          "dev": true
+        }
+      }
+    },
     "graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
@@ -6996,6 +7021,12 @@
         "ajv-errors": "^1.0.0",
         "ajv-keywords": "^3.1.0"
       }
+    },
+    "scriptjs": {
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/scriptjs/-/scriptjs-2.5.9.tgz",
+      "integrity": "sha512-qGVDoreyYiP1pkQnbnFAUIS5AjenNwwQBdl7zeos9etl+hYKWahjRTfzAZZYBv5xNHx7vNKCmaLDQZ6Fr2AEXg==",
+      "dev": true
     },
     "select-hose": {
       "version": "2.0.0",

--- a/p2plending/frontend/package.json
+++ b/p2plending/frontend/package.json
@@ -32,6 +32,7 @@
     "eslint": "^5.16.0",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.13.0",
+    "google-map-react": "^1.1.4",
     "prettier": "1.17.0",
     "prop-types": "^15.7.2",
     "query-string": "^6.5.0",

--- a/p2plending/frontend/src/app/App.js
+++ b/p2plending/frontend/src/app/App.js
@@ -2,7 +2,7 @@
 import React, { Component } from "react";
 import { BrowserRouter, Route, Switch } from "react-router-dom";
 import TitlesResults from "./titles/TitlesResults";
-
+import TitlesSpecific from "./titles/TitlesSpecific";
 import Landing from "./landing/Landing";
 import Footer from "./Footer";
 import Header from "./Header";
@@ -22,6 +22,7 @@ class App extends Component {
               <Route exact path="/" component={Landing} />
               <Route exact path="/search" exact component={TitlesResults} />
               <Route exact path="/search/:languageID" exact component={TitlesResults} />
+              <Route exact path="/titles/:titleID" exact component={TitlesSpecific} />
               <Route component={NotFound} />
             </Switch>
           </div>

--- a/p2plending/frontend/src/app/Header.js
+++ b/p2plending/frontend/src/app/Header.js
@@ -1,25 +1,31 @@
 import React, { Component } from "react";
 import { Link, withRouter } from "react-router-dom";
 import LoginModal from "./auth/LoginModal";
+import SignupModal from "./auth/SignupModal";
 
 class Header extends Component {
   state = {
-    showModal: false,
-    content: [],
-    isLoading: true,
+    showLoginModal: false,
+    showSignupModal: false
   };
 
-  onOpenModal = () => this.setState({ showModal: true });
+  onOpenLoginModal = () => this.setState({ showLoginModal: true });
+  onOpenSignupModal = () => this.setState({ showSignupModal: true });
 
-  onCloseModal = () => {
-    this.setState({ showModal: false });
+  onCloseLoginModal = () => {
+    this.setState({ showLoginModal: false });
+  };
+
+  onCloseSignupModal = () => {
+    this.setState({ showSignupModal: false });
   };
 
   render() {
 
     return (
       <div className="header">
-        <LoginModal isOpen={this.state.showModal} onClose={this.onCloseModal} />
+        <LoginModal isOpen={this.state.showLoginModal} onClose={this.onCloseLoginModal} />
+        <SignupModal isOpen={this.state.showSignupModal} onClose={this.onCloseSignupModal} />
         <div className="container container--full d-flex justify-content-between align-items-center py-2 w-100">
         <div className="d-flex align-items-center">
               <Link
@@ -37,7 +43,7 @@ class Header extends Component {
                   <button
                     className="btn btn-sm btn-outline-dark d-flex px-3 py-2"
                     onClick={() => {
-                      this.onOpenModal();
+                      this.onOpenLoginModal();
                     }}
                   >
                     <small className="font-weight-bold">LOG IN</small>
@@ -47,7 +53,7 @@ class Header extends Component {
                   <button
                     className="btn btn-sm btn-dark d-flex px-3 py-2"
                     onClick={() => { 
-                      this.onOpenModal();
+                      this.onOpenSignupModal();
                     }}
                   >
                     <small className="font-weight-bold">SIGN UP</small>

--- a/p2plending/frontend/src/app/Header.js
+++ b/p2plending/frontend/src/app/Header.js
@@ -51,7 +51,7 @@ class Header extends Component {
                 </li>
                 <li className="list-inline-item ml-1" key={2}>
                   <button
-                    className="btn btn-sm btn-dark d-flex px-3 py-2"
+                    className="btn btn-sm btn-primary d-flex px-3 py-2"
                     onClick={() => { 
                       this.onOpenSignupModal();
                     }}

--- a/p2plending/frontend/src/app/auth/LoginModal.js
+++ b/p2plending/frontend/src/app/auth/LoginModal.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import Modal from "react-modal";
-
+import { Link, withRouter } from "react-router-dom";
 
 import Octicon from "../../components/Octicon";
 
@@ -17,28 +17,36 @@ const LoginModal = ({ isOpen, onClose }) => (
     <button className="loginModal-close btn btn-reset p-2" onClick={onClose}>
       <Octicon name="x" />
     </button>
-    <div className="py-5 px-4 my-2 mx-auto" style={{ maxWidth: "400px" }}>
-      <div className="text-center mx-auto">
-        <h5 className="mb-1">Login to { title }</h5>
-        <p className="text-secondary font-weight-light">
-          Sign in to save your progress.
-        </p>
-      </div>
-      <div className="d-flex justify-content-center mt-4">
-        <a
-          className="loginModal-button btn btn-sm btn-outline-dark"
-          href="http:google.com/"
-        >
-          <small className="font-weight-bold">Log in</small>
-        </a>
-      </div>
-      <div className="text-center mt-2" style={{ opacity: 0.5 }}>
-        <small className="text-muted">
-          We will never post to your account without your permission.
-        </small>
+    <div className="container">
+      <div className="py-5 px-4 my-2 mx-auto" style={{ maxWidth: "400px" }}>
+        <div className="text-center mx-auto">
+          <h5 className="mb-1">Login to { title }</h5>
+          <p className="text-secondary font-weight-light">
+            Sign in to save your progress.
+          </p>
+        </div>
+        <div className="row justify-content-md-center">
+
+              <button
+                className="btn btn-sm btn-success d-flex px-3 py-2"
+              >
+                <small className="font-weight-bold">LOG IN</small>
+              </button>
+ 
+        </div>
+        <div className="text-center mt-2" style={{ opacity: 0.5 }}>
+          <Link
+            to="/privacy"
+            className="d-flex align-items-center"
+          >
+          <small>
+            We will never post to your account without your permission.
+          </small>
+          </Link>
+        </div>
       </div>
     </div>
   </Modal>
 );
 
-export default LoginModal;
+export default withRouter(LoginModal);

--- a/p2plending/frontend/src/app/auth/SignupModal.js
+++ b/p2plending/frontend/src/app/auth/SignupModal.js
@@ -1,0 +1,41 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import Modal from "react-modal";
+
+import Octicon from "../../components/Octicon";
+import MapContainer from "../../components/MapContainer";
+
+const config = require("../../../config/index");
+
+const title = config.title;
+
+Modal.setAppElement("#root");
+
+const SignupModal = ({ isOpen, onClose }) => (
+  <Modal isOpen={isOpen} className="loginModal" overlayClassName="loginModal-overlay">
+    <button className="loginModal-close btn btn-reset p-2" onClick={onClose}>
+      <Octicon name="x" />
+    </button>
+    <div className="container py-5 my-2 mx-auto" style={{ maxWidth: "400px" }}>
+        <div className="row">
+            <div className="col-sm pl-0 pr-1">
+                <div className="col-sm p-0">
+                    <h5 className="mb-1">Sign Up for { title }</h5>
+                </div>
+                <p className="text-secondary font-weight-light">
+                    { title } is a community based peer to peer sharing application.
+                    In order to sign up for this application you must go to the nearest participating library
+                    and opt into the system using your library card. Drop by and ask about {" "} { title }
+                </p>
+            </div>
+            <div className="col-md pl-1 text-center">
+                <div style={{ height: "300px", width: '100%' }}>
+                    <MapContainer/>
+                </div>
+            </div>
+      </div>
+    </div>
+  </Modal>
+);
+
+export default SignupModal;

--- a/p2plending/frontend/src/app/backendCalls.js
+++ b/p2plending/frontend/src/app/backendCalls.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /* eslint-disable no-unused-vars */
 import axios from "axios";
 import queryString from "query-string";
@@ -39,7 +38,10 @@ export const fetchAllTitles = () => {
     return axios.get("/api/v1/titles");
 }
 
-export const searchContent = search => {
-    // return axios.get(`/api/search?${queryString.stringify({ text: search })}`);
-    console.log("this is where we would search the backend")
+export const fetchContentTitle = id => {
+    return axios.get(`/api/v1/titles/${ id }`);
+};
+
+export const searchContentTitles = search => {
+    return axios.get(`/api/v1/titles/?${queryString.stringify({ search })}`);
 };

--- a/p2plending/frontend/src/app/landing/Landing.js
+++ b/p2plending/frontend/src/app/landing/Landing.js
@@ -10,11 +10,11 @@ const title = config.title;
 class Titles extends Component {
   render() {
     return (
-        <div id="container p-4 my-5">
+        <div id="container p-4 my-3">
 
           <div
-            className="opening-blurb border rounded p-4 text-center "
-            style={{ borderColor: "#e8e8e8" }}
+            className="opening-blurb border rounded p-4 text-center text-white"
+            style={{ background: "#2a2f35", borderBottom: "1px solid #e8e8e8" }}
           >
             <span role="img" aria-label="emoji" style={{fontSize: 50}}>
               📖
@@ -36,8 +36,13 @@ class Titles extends Component {
           <div className="mt-2">
             <BrowseByLanguage />
           </div>
-          <div className="mx-auto " style={{ maxWidth: "400px" }}>
-            <CallToAction />
+          <div
+            className="opening-blurb border rounded p-3 my-5 text-center text-white bg-secondary "
+            style={{ borderBottom: "1px solid #e8e8e8" }}
+          >
+            <div className="mx-auto " style={{ maxWidth: "400px" }}>
+              <CallToAction />
+            </div>
           </div>
         </div>
     );

--- a/p2plending/frontend/src/app/landing/Landing.js
+++ b/p2plending/frontend/src/app/landing/Landing.js
@@ -13,8 +13,7 @@ class Titles extends Component {
         <div id="container p-4 my-3">
 
           <div
-            className="opening-blurb border rounded p-4 text-center text-white"
-            style={{ background: "#2a2f35", borderBottom: "1px solid #e8e8e8" }}
+            className="opening-blurb border rounded p-4 text-center text-white bg-dark"
           >
             <span role="img" aria-label="emoji" style={{fontSize: 50}}>
               📖
@@ -23,8 +22,8 @@ class Titles extends Component {
             <div className="mx-auto" style={{ maxWidth: "500px" }}>
               <span>
                 { title } is a Peer to Peer Book Exchange! Share and explore the books within your local community.{" "}
-                <span role="img" aria-label="Tada emoji">
-                  📚
+                <span role="img" aria-label="Globex emoji">
+                  🌎
                 </span>
               </span>
             </div>

--- a/p2plending/frontend/src/app/titles/TitlesSpecific.js
+++ b/p2plending/frontend/src/app/titles/TitlesSpecific.js
@@ -3,11 +3,10 @@ import React, { Component } from "react";
 import SearchBar from "../../components/SearchBar";
 import queryString from "query-string";
 
-class TitlesResults extends Component {
+class TitlesSpecific extends Component {
   state = {
     searchString: ""
   }
-  
   componentDidMount(){
     // eslint-disable-next-line react/prop-types
     const values = queryString.parse(this.props.location.search)
@@ -16,10 +15,8 @@ class TitlesResults extends Component {
       this.setState({ searchString: Object.keys(values)[0] })
     }
   }
-
   render() {
     const { searchString } = this.state
-
     return (
         <div id="container p-4 my-5">
 
@@ -27,19 +24,17 @@ class TitlesResults extends Component {
             className="opening-blurb border rounded p-4 text-center text-white bg-primary"
           >
             <span role="img" aria-label="emoji" style={{fontSize: 50}}>
-              📚
+              📖
             </span>
-            <h2 className="m-0">Search Results: { searchString }</h2>
+            <h2 className="m-0">Specific Title Results Page</h2>
+            <div className="mx-auto" style={{ maxWidth: "500px" }}>
+
+            </div>
           </div>
 
-          <div className="flex-container pt-2"> 
-            <SearchBar
-              value={ searchString }
-            />
-          </div>
         </div>
     );
   }
 }
 
-export default TitlesResults;
+export default TitlesSpecific;

--- a/p2plending/frontend/src/components/BrowseByLanguage.js
+++ b/p2plending/frontend/src/components/BrowseByLanguage.js
@@ -13,7 +13,7 @@ class BrowseByLanguage extends Component {
     }
 
     fetchLanguages = () => {
-    
+   
         // no ties to backend
         this.setState({ languages: api.fetchAllLanguages() })
 
@@ -34,22 +34,22 @@ class BrowseByLanguage extends Component {
                 <div className="border rounded mx-auto" style={{ maxWidth:"350px" }}>
                     <div className="container container--full px-2 my-1">
                         <div className="d-flex align-items-center justify-content-between mb-1" />
-                            {languages.length > 0 ? (
-                                <div className="row">
-                                    {languages.map(item => (
-                                        <LanguageItem 
-                                          key={item.id}
-                                          name={item.name}
-                                          number={item.number}
-                                        />
-                                    ))}
-                                </div>
-                            ) : (
-                                <div className="blankslate py-5 my-2">
-                                    <h1 className="m-0">No Languages Found</h1>
-                                    <p>Please check your internet connection </p>
-                                </div>
-                            )}
+                        {languages.length > 1 ? (
+                          <div className="row">
+                              {languages.map((item, index) => (
+                                <LanguageItem 
+                                  key={index}
+                                  name={item.name}
+                                  number={item.number}
+                                />
+                              ))}
+                          </div>
+                        ) : (
+                          <div className="blankslate py-5 my-2">
+                              <h1 className="m-0">No Languages Found</h1>
+                              <p>Please check your internet connection </p>
+                          </div>
+                        )}
                     </div>
                 </div>
             </div>

--- a/p2plending/frontend/src/components/CallToAction.js
+++ b/p2plending/frontend/src/components/CallToAction.js
@@ -1,23 +1,52 @@
-import React from "react";
-import { Link } from "react-router-dom";
+import React, { Component }  from "react";
+import SignupModal from "../app/auth/SignupModal";
 
-const CallToAction = () => (
-  <div className="container p-4">
-    <Link to="/" className="text-dark d-flex align-items-center mb-2 ">
-      <div className="text-center border border-primary rounded p-2" >
-        <span style={{ fontSize: "30px" }} role="img" aria-label="embarrassed emoji">
-          🔔
-        </span>
-        <p className="text-dark" style={{ fontWeight: "500" }}>
-          Have books you would want to share? Sign up to become a Lender today.
-        </p>
-        <p className="text-dark pt-0" style={{ fontWeight: "700" }}>
-          Click here to learn more.
-        </p>
+class CallToAction extends Component {
+  state = {
+    showSignupModal: false,
+  };
+
+  onOpenSignupModal = () => this.setState({ showSignupModal: true });
+
+  onCloseSignupModal = () => {
+    this.setState({ showSignupModal: false });
+  };
+
+  render() {
+
+    return (
+      <div className="container my-5 border rounded bg-light text-dark text-center" style={{ maxWidth: "400px" }}>
+        <SignupModal isOpen={this.state.showSignupModal} onClose={this.onCloseSignupModal} />
+        <div className="row justify-content-md-center ">
+          <div className="col col-md-auto "  style={{ maxWidth: "400px" }}>
+            <p className="text-dark my-3" style={{ fontWeight: "900" }}>
+              Have books you would want to share? Sign up and become a Lender today!
+            </p>
+          </div>
+        </div>
+        <div className="row">
+          <div className="col">
+            <span style={{ fontSize: "40px" }} role="img" aria-label="embarrassed emoji">
+              🔔
+            </span>
+          </div>
+          <div className="col-md-auto">
+            <button  
+              className="btn btn-md btn-primary my-3"
+              onClick={() => { 
+                this.onOpenSignupModal();
+              }}
+            >
+              Sign Up - It&apos;s free
+            </button>
+          </div>
+        </div>
+        {/* <div className="row justify-content-md-center my-2">
+
+        </div> */}
       </div>
-    </Link>
-  </div>
-);
-
+    );
+  }
+}
   
   export default CallToAction;

--- a/p2plending/frontend/src/components/CallToAction.js
+++ b/p2plending/frontend/src/components/CallToAction.js
@@ -28,11 +28,6 @@ class CallToAction extends Component {
           </div>
         </div>
         <div className="row">
-          {/* <div className="col">
-            <span style={{ fontSize: "40px" }} role="img" aria-label="embarrassed emoji">
-              🔔
-            </span>
-          </div> */}
           <div className="col">
             <button  
               className="btn btn-md btn-primary my-3"
@@ -44,9 +39,6 @@ class CallToAction extends Component {
             </button>
           </div>
         </div>
-        {/* <div className="row justify-content-md-center my-2">
-
-        </div> */}
       </div>
     );
   }

--- a/p2plending/frontend/src/components/CallToAction.js
+++ b/p2plending/frontend/src/components/CallToAction.js
@@ -15,29 +15,32 @@ class CallToAction extends Component {
   render() {
 
     return (
-      <div className="container my-5 border rounded bg-light text-dark text-center" style={{ maxWidth: "400px" }}>
+      <div className="container my-2 py-1 bg-secondary text-center" style={{ maxWidth: "400px" }}>
         <SignupModal isOpen={this.state.showSignupModal} onClose={this.onCloseSignupModal} />
         <div className="row justify-content-md-center ">
-          <div className="col col-md-auto "  style={{ maxWidth: "400px" }}>
-            <p className="text-dark my-3" style={{ fontWeight: "900" }}>
-              Have books you would want to share? Sign up and become a Lender today!
+          <div className="col "  style={{ maxWidth: "400px" }}>
+            <p className="h5 text-white my-0" style={{ fontWeight: "500" }}>
+              Have books you would want to share?
+            </p>
+            <p className="h5 text-white my-0" style={{ fontWeight: "500" }}>
+              Sign up and become a Lender today!
             </p>
           </div>
         </div>
         <div className="row">
-          <div className="col">
+          {/* <div className="col">
             <span style={{ fontSize: "40px" }} role="img" aria-label="embarrassed emoji">
               🔔
             </span>
-          </div>
-          <div className="col-md-auto">
+          </div> */}
+          <div className="col">
             <button  
               className="btn btn-md btn-primary my-3"
               onClick={() => { 
                 this.onOpenSignupModal();
               }}
             >
-              Sign Up - It&apos;s free
+              Sign Up - It&apos;s Free!
             </button>
           </div>
         </div>

--- a/p2plending/frontend/src/components/LanguageItem.js
+++ b/p2plending/frontend/src/components/LanguageItem.js
@@ -6,14 +6,13 @@ class LanguageItem extends Component {
   
   static propTypes = {
     name: PropTypes.string.isRequired,
-    key: PropTypes.number.isRequired,
     number: PropTypes.number.isRequired,
   }
 
   render() {
     
     return (
-      <div className="deck-item col-4 col-sm-3 col-md-4 col-lg-3 d-flex" key={this.props.key}>
+      <div className="deck-item col-4 col-sm-3 col-md-4 col-lg-3 d-flex">
         ⚈ <Link
           to={`/search/${this.props.name.toString().toLowerCase()}`}
           className="d-flex flex-column justify-content-between text-dark mb-1 p-1 w-50 position-relative"

--- a/p2plending/frontend/src/components/MapContainer.js
+++ b/p2plending/frontend/src/components/MapContainer.js
@@ -1,0 +1,38 @@
+import React, { Component } from 'react';
+import GoogleMap from 'google-map-react';
+
+// eslint-disable-next-line react/prop-types
+const CustomMarker = ({ emoji }) => (
+  <div className="container p-0 m-0">
+      <span role="img" aria-label="emoji" style={{fontSize: 30}}>
+        { emoji }
+      </span>
+      <p className="w-100" style={{fontSize:"10px"}}> Linda Vista Library </p>
+    </div>
+);
+
+class MapContainer extends Component {
+
+  render() {
+    return (
+      <GoogleMap
+        // eslint-disable-next-line no-undef
+        bootstrapURLKeys={{ key: process.env.REACT_APP_MAP_KEY }}
+        defaultCenter={{
+          lat: 32.783588,
+          lng: -117.170181
+        }}
+        defaultZoom={19}
+        yesIWantToUseGoogleMapApiInternals={true}
+      >
+        <CustomMarker
+            lat={32.783588}
+            lng={-117.170181}
+            emoji="📖"
+          />
+      </GoogleMap>
+    );
+  }
+}
+
+export default MapContainer;

--- a/p2plending/frontend/src/components/SearchBar.js
+++ b/p2plending/frontend/src/components/SearchBar.js
@@ -1,24 +1,28 @@
 /* eslint-disable no-unused-vars */
 import React, { Component } from "react";
-import { withRouter } from "react-router-dom";
+import { Link, withRouter } from "react-router-dom";
 import { debounce } from "lodash";
 import PropTypes from "prop-types";
-
+import queryString from "query-string";
 import * as api from "../app/backendCalls";
 import Octicon from "./Octicon";
 
 class SearchBar extends Component {
   state = {
     content: [],
-    searchString: "",
+    searchString: this.props.value,
     isFocused: false,
     isLoading: false,
   };
+  
   static propTypes = {
     history: PropTypes.any.isRequired,
+    value: PropTypes.string
   }
+
   componentDidMount() {
     this.searchContent("*");
+    
   }
 
   componentWillUnmount() {
@@ -41,10 +45,9 @@ class SearchBar extends Component {
   };
 
   searchContent = debounce(value => {
-    // api.searchContent(value).then(({ data }) => {
-    //   console.log(data);
-    //   this.setState({ content: data, isLoading: false });
-    // });
+    api.searchContentTitles(value).then(({ data }) => {
+      this.setState({ content: data, isLoading: false });
+    });
   }, 300);
 
   onBlur = e => {
@@ -54,6 +57,7 @@ class SearchBar extends Component {
 
   render() {
     const { content, searchString, isFocused, isLoading } = this.state;
+
     return (
       <form
         className="mt-3 flex-item search border rounded d-flex align-items-center position-relative p-2"
@@ -75,6 +79,32 @@ class SearchBar extends Component {
           className="search-input"
           placeholder="Search for titles or topics..."
         />
+          {isFocused && (
+            <div className="search-overlay position-absolute bg-white rounded border border-muted">
+              {isLoading && (
+                <div className="py-2 px-3 text-muted">
+                  <i className="fas fa-spinner fa-spin mr-1" />
+                  <span>Searching for Books...</span>
+                </div>
+              )}
+              {!isLoading &&
+                content.length > 0 && (
+                  <div className="text-dark d-flex flex-column py-2">
+                    {content.slice(0, 6).map(el => (
+                      <Link to={`/titles/${el.id}`} className="py-2 px-3 text-dark" key={el.id}>
+                        {el.title}
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              {!isLoading &&
+                content.length === 0 && (
+                  <div className="py-2 px-3 text-muted">
+                    No titles found matching {searchString}
+                  </div>
+                )}
+            </div>
+          )}
       </form>
     );
   }

--- a/p2plending/lending/models.py
+++ b/p2plending/lending/models.py
@@ -59,6 +59,7 @@ class Profile(models.Model):
         return self.titlerequest_set.filter(status="requested")
 
 class Title(models.Model):
+    id = models.AutoField(primary_key=True)
     language = models.CharField(max_length=16,choices=LANGUAGES,blank=True,null=True)  
     title = models.CharField(max_length=255)
     author = models.CharField(max_length=255,blank=True,null=True)

--- a/p2plending/lending/serializers.py
+++ b/p2plending/lending/serializers.py
@@ -5,7 +5,7 @@ from .models import Location,Profile,Title,Item,Loan,TitleRequest
 class TitleSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Title
-        fields = ('title','author','publish_year','language','cover_image','media_type','description')
+        fields = ('id', 'title','author','publish_year','language','cover_image','media_type','description')
 
 class TitleDetailSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:


### PR DESCRIPTION
1. Tied Search Bar to the backend with two different routing habits:
   - Can route directly to a title name by selecting on the title.
   - Can route to a search results page by the query

2. Styled Sign Up Modal with Google Map that points at Library Locations
3. Cleaned up Login Modal
4. Fixed Component Maping keying bug

Addresses Issue #5

![bitmoji](https://render.bitstrips.com/v2/cpanel/c0070b40-8c33-4e40-9d93-d880ca58c92d-f35a46c4-b1dd-4da0-a9de-3b0fa0f211ba-v1.png?transparent=1&palette=1&width=246)