### PR TITLE
Fix format of login modal. Change Webpack config  for images

### DIFF
--- a/p2plending/frontend/src/app/auth/LoginModal.js
+++ b/p2plending/frontend/src/app/auth/LoginModal.js
@@ -19,21 +19,21 @@ const LoginModal = ({ isOpen, onClose }) => (
     <button className="loginModal-close btn btn-reset p-2" onClick={onClose}>
       <Octicon name="x" />
     </button>
-    <div className="container">
-      <div className="py-5 px-4 my-2 mx-auto" style={{ maxWidth: "400px" }}>
-        <div className="text-center mx-auto">
+    <div className="container text-center">
+      <div className="py-5 px-4 my-2 mx-auto" style={{ maxWidth: "300px" }}>
+        <div className="mx-auto">
           <h5 className="mb-1">Login to { title }</h5>
           <p className="text-secondary font-weight-light">
             Sign in to save your progress.
           </p>
         </div>
-        <div className="row justify-content-md-center">
+        <div className="row">
             <LoginForm signalClose={onClose}></LoginForm>
         </div>
-        <div className="text-center mt-2" style={{ opacity: 0.5 }}>
+        <div className="mt-2" style={{ opacity: 0.5 }}>
           <Link
             to="/privacy"
-            className="d-flex align-items-center"
+            className="d-flex"
           >
           <small>
             We will never post to your account without your permission.

--- a/p2plending/frontend/src/components/LoginForm.js
+++ b/p2plending/frontend/src/components/LoginForm.js
@@ -61,15 +61,17 @@ class LoginForm extends React.Component {
       return (
         <form onSubmit={this.handleSubmit}>
           {form_error} 
-          <label>
-            Username:
+          <div className="text-right">
+          <label >
+            Username:{' '} 
             <input type="text" name="username" value={this.state.username} onChange={this.handleInputChange} />
           </label>
           <label>
-            Name:
+            Name: {' '} 
             <input type="password" name="password" value={this.state.password} onChange={this.handleInputChange} />
           </label>
-          <input type="submit" value="Submit" />
+          </div>
+          <button type="submit" class="btn btn-outline-dark m-2">Submit</button>
         </form>
       );
    }

--- a/p2plending/frontend/webpack.config.js
+++ b/p2plending/frontend/webpack.config.js
@@ -20,7 +20,9 @@ module.exports = {
         use: [
           {
             loader: 'file-loader',
-            options: {},
+            options: {
+              name: '[path][name].[ext]',
+            },
           },
         ],
       }


### PR DESCRIPTION
Improved formatting of login modal window, changed to Bootstrap Submit button, and changed Webpack config to retain orginal image names and location so they are not substituted with something like .../dist/66634523.gif which would pollute code base unless gitignore is changed.