### PR TITLE
Tabs/Sidebar for different Order Statuses

### DIFF
--- a/p2plending/frontend/src/app/App.js
+++ b/p2plending/frontend/src/app/App.js
@@ -34,6 +34,7 @@ class App extends Component {
               <Route exact path="/titles/:titleID" exact component={TitleIndividual} />
               <Route exact path="/settings/profile" component={Settings} />
               <Route exact path="/:username" component={ReqUser(OrderStatus)} />
+              <Route exact path="/:username/:tabName" component={ReqUser(OrderStatus)} />
               <Route exact path="/about" component={About} />
               <Route exact path="/privacy" component={Privacy} />
               <Route exact path="/terms" component={Terms} />

--- a/p2plending/frontend/src/app/auth/ReqUser.js
+++ b/p2plending/frontend/src/app/auth/ReqUser.js
@@ -9,22 +9,23 @@ const ReqUser = ComposedComponent => {
     state = { user: {}, isLoading: false, isError: false };
 
     componentDidMount() {
-      // eslint-disable-next-line react/prop-types
-      const { username } = this.props.match.params;
-      if (username) {
-        this.fetchUserProfile(username);
+
+      if(this.state.user != {}) {
+        // eslint-disable-next-line react/prop-types
+        const { username } = this.props.match.params;
+        if (username) {
+          this.fetchUserProfile(username);
+        }
       }
     }
 
     fetchUserProfile = username => {
       this.setState({ isLoading: true });
-      // How the Actual Backend Call Should Look Like
-      // api
-      //   .fetchUserProfile(username)
-      //   .then(({ data }) => this.setState({ user: data, isLoading: false }))
-      //   .catch(() => this.setState({ isError: true, isLoading: false }));
-      api.getUserName()
-      this.setState({ isLoading: false })
+      api
+        .fetchUserProfile(username)
+        .then(({ data }) => this.setState({ user: data, isLoading: false }))
+        .catch(() => this.setState({ isError: true, isLoading: false }));
+
     };
 
     render() {
@@ -41,7 +42,7 @@ const ReqUser = ComposedComponent => {
       if (isError || (!isLoading && Object.keys(user).length === 0)) {
         return <NotFound />;
       }
-      return <ComposedComponent {...this.props} profile={user} />;
+      return <ComposedComponent {...this.props} user={user} />;
     }
   }
 

--- a/p2plending/frontend/src/app/backendCalls.js
+++ b/p2plending/frontend/src/app/backendCalls.js
@@ -57,7 +57,7 @@ export const fetchUserProfile = ( username ) => {
 export const getUserName = () => {
     console.log("backend call to get User Data")
     const user = {
-      username : "test-username"
+      username : "admin"
     }
     return user;
 };

--- a/p2plending/frontend/src/app/profile/LentSection.js
+++ b/p2plending/frontend/src/app/profile/LentSection.js
@@ -1,0 +1,32 @@
+/* eslint-disable no-console */
+/* eslint-disable react/prop-types */
+import React, { Component } from "react";
+
+class LentSection extends Component {
+
+  render() {
+    const { lender_items, is_lender } = this.props;
+    console.log(lender_items)
+    console.log(is_lender)
+    return (
+      <div>
+            <div className="page-header">
+                <h2>Items You Have Lent</h2>
+              </div>
+              <p className="lead"></p>
+              <hr></hr>
+              <div className="row">
+                <div className="col-lg-12">
+                  <div className="m-1 w-100 h-100" style={{ background: "#f9f9f9", border: "1px solid #e8e8e8" }}>
+                    If the user is an approved lender they will be able to see what items they have lent out here. Otherwise we will present the user with a dialog
+                    on how to become an approved lender
+                    {/* Actual Content Goes Here */}
+                  </div>
+                </div>
+              </div>
+      </div>
+    );
+  }
+}
+
+export default LentSection;

--- a/p2plending/frontend/src/app/profile/LoansSection.js
+++ b/p2plending/frontend/src/app/profile/LoansSection.js
@@ -1,0 +1,30 @@
+/* eslint-disable no-console */
+/* eslint-disable react/prop-types */
+import React, { Component } from "react";
+
+
+class LoansSection extends Component {
+
+  render() {
+
+    return (
+      <div>
+            <div className="page-header">
+                <h2>Loaned Items</h2>
+              </div>
+              <p className="lead"></p>
+              <hr></hr>
+              <div className="row">
+                <div className="col-lg-12">
+                  <div className="m-1 w-100 h-100" style={{ background: "#f9f9f9", border: "1px solid #e8e8e8" }}>
+                    Books that have gone from the requests to actually loaned out to the user will go here. 
+                    {/* Actual Content Goes Here */}
+                  </div>
+                </div>
+              </div>
+      </div>
+    );
+  }
+}
+
+export default LoansSection;

--- a/p2plending/frontend/src/app/profile/OrderStatus.js
+++ b/p2plending/frontend/src/app/profile/OrderStatus.js
@@ -1,17 +1,154 @@
+/* eslint-disable no-console */
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
+import LentSection from "./LentSection";
+import LoansSection from "./LoansSection";
+import RequestsSection from "./RequestsSection";
+import { Redirect } from "react-router-dom";
+import Tab from "../../components/Tab";
 
-
+const TABS = {
+  LENT: "lents",
+  LOANS: "loans",
+  REQUESTED: "requested",
+};
 
 class OrderStatus extends Component {
   state = {
-
+    user: {},
+    activeTab: TABS.REQUESTED,
+    isError: false,
   };
 
+  UNSAFE_componentWillUpdate(nextProps) {
+    const { params } = nextProps.match;
+    if (nextProps.match !== this.props.match) {
+      if (params.tabName && params.tabName.length > 0) {
+        this.setState({ activeTab: params.tabName });
+      }
+    }
+  }
+
+  componentDidMount() {
+    // eslint-disable-next-line react/prop-types
+    const { params } = this.props.match;
+    if (params.tabName && params.tabName.length > 0) {
+      this.setState({ activeTab: params.tabName });
+    }
+  }
+
+  onTabSelect = value => {
+    const { username } = this.props.match.params;
+    this.props.history.push(`/${username}/${value}`);
+    this.setState({ activeTab: value });
+  };
+  
+  onGoTo = () => this.props.history.push("/settings/profile");
+
   render() {
+    const { user } = this.props;
+    const { activeTab, isRedirect } = this.state;
+
+    console.log("State in Order Status")
+    console.log(this.state)
+
+    console.log("User Props in Order Status")
+    console.log(user)
+
+    if (isRedirect) {
+      return <Redirect to="/" />;
+    }
+
 
     return (
-      <div>
 
+      <div>
+        <div
+          className="profile-header pt-4 pb-4"
+          style={{ background: "#f9f9f9", borderBottom: "1px solid #e8e8e8" }}
+        >
+          <div className="container container--full">
+            <div className="d-flex flex-column-reverse flex-lg-row justify-content-between align-items-lg-center">
+              <div className="d-flex align-items-center">
+                <div className="row">
+                  <div className="col-sm">
+                    <h1 className="m-0">{user.name}</h1>
+                    {user.username && <h6 className="text-muted m-0">@{user.username}</h6>}
+                  </div>
+                  <div className="col-sm">
+                    <button
+                      onClick={this.onGoTo}
+                      className="btn btn-sm btn-white text-uppercase d-flex align-items-center px-3 mt-2"
+                    >
+                      <small className="font-weight-medium">Edit Profile</small>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+          <div className="container-fluid">
+            <div className="row d-flex d-md-block flex-nowrap wrapper">
+              <div className="col-md-3 float-left col-1 pl-0 pr-0 collapse width show" id="sidebar">
+                <div className="list-group border-0 card text-center text-md-left">
+                 
+                  <a href="#" onClick={() => this.onTabSelect(TABS.REQUESTED)}  className="list-group-item d-inline-block collapsed">
+                    <i className="sidebar-icon fa fa-book"></i>
+                    <span className="d-none d-md-inline"> 
+                      <div style={{ background: "", border: "" }}>
+                        <Tab active={activeTab === TABS.REQUESTED}>
+                          Requested ({user.active_requests})
+                        </Tab>
+                      </div>
+                    </span>
+                  </a>
+
+                  <a href="#" onClick={() => this.onTabSelect(TABS.LOANS)} className="list-group-item d-inline-block collapsed">
+                    <i className="sidebar-icon fa fa-book-open"></i> 
+                    <span className="d-none d-md-inline">
+                      <div style={{ background: "", border: "" }}>
+                        <Tab  active={activeTab === TABS.LOANS}>
+                          Loaned ({user.active_loans})
+                        </Tab>
+                      </div>
+                    </span>
+                  </a>
+
+                  <a href="#" onClick={() => this.onTabSelect(TABS.LENT)} className="list-group-item d-inline-block collapsed">
+                    <i className="sidebar-icon fa fa-gift"></i> 
+                    <span className="d-none d-md-inline">
+                      <div style={{ background: "", border: "" }}>
+                        <Tab  active={activeTab === TABS.LENT}>
+                          Lent ({user.lender_items.length})
+                        </Tab>
+                      </div>
+                    </span>
+                  </a>
+                </div>
+              </div>
+            </div>
+
+            <main className="col-md-9 float-left col px-5 pl-md-2 pt-2 main">
+              {activeTab === TABS.REQUESTED && (
+                <RequestsSection
+                />
+              )}
+
+              {activeTab === TABS.LOANS && (
+                <LoansSection
+                />
+              )}
+
+              {activeTab === TABS.LENT && (
+                <LentSection
+                  lender_items={user.lender_items}
+                  is_lender={user.is_lender}
+                />
+              )}   
+            </main>
+          </div>
       </div>
     );
   }

--- a/p2plending/frontend/src/app/profile/RequestsSection.js
+++ b/p2plending/frontend/src/app/profile/RequestsSection.js
@@ -1,0 +1,30 @@
+/* eslint-disable no-console */
+/* eslint-disable react/prop-types */
+import React, { Component } from "react";
+
+
+class RequestSection extends Component {
+
+  render() {
+
+    return (
+      <div>
+            <div className="page-header">
+                <h2>Requested Items</h2>
+              </div>
+              <p className="lead"></p>
+              <hr></hr>
+              <div className="row">
+                <div className="col-lg-12">
+                  <div className="m-1 w-100 h-100" style={{ background: "#f9f9f9", border: "1px solid #e8e8e8" }}>
+                    Whenever a user &quot;requests&quot; a book, those requests will land here until they are ready for pickup/have been picked up
+                    {/* Actual Content Goes Here */}
+                  </div>
+                </div>
+              </div>
+      </div>
+    );
+  }
+}
+
+export default RequestSection;

--- a/p2plending/frontend/src/components/Tab.js
+++ b/p2plending/frontend/src/components/Tab.js
@@ -1,0 +1,22 @@
+import React from "react";
+import cx from "classnames";
+
+// eslint-disable-next-line react/prop-types
+const Tab = ({ active, children, onClick }) => (
+  <div
+    onClick={onClick}
+    className={cx("text-uppercase py-2 px-3", { "border-primary": active })}
+    style={{ borderBottom: active ? "2px solid blue" : "none", cursor: "pointer" }}
+  >
+    <span
+      className={cx("small font-weight-medium", {
+        "text-primary": active,
+        "text-muted": !active,
+      })}
+    >
+      {children}
+    </span>
+  </div>
+);
+
+export default Tab;

--- a/p2plending/frontend/src/index.css
+++ b/p2plending/frontend/src/index.css
@@ -223,3 +223,125 @@ h1 {
   text-transform: uppercase;
   color: #e8e8e8;
 }
+
+/*Sidebar Content*/
+#sidebar {
+  overflow: hidden;
+  z-index: 3;
+}
+.sidebar-icon {
+  display: none;
+}
+#sidebar .list-group {
+  min-width: 100px;
+  background-color: #343a40!important;
+  min-height: 100vh;
+}
+#sidebar i {
+  margin-right: 6px;
+}
+
+#sidebar .list-group-item {
+  border-radius: 0;
+  background-color: #343a40!important;
+  color: #ccc;
+  border-left: 0;
+  border-right: 0;
+  border-color: #2c2c2c;
+  white-space: nowrap;
+}
+
+/* highlight active menu */
+#sidebar .list-group-item:not(.collapsed) {
+  background-color: #343a40!important;
+}
+
+/* closed state */
+#sidebar .list-group .list-group-item[aria-expanded="false"]::after {
+content: " \f0d7";
+font-family: FontAwesome;
+display: inline;
+text-align: right;
+padding-left: 5px;
+}
+
+/* open state */
+#sidebar .list-group .list-group-item[aria-expanded="true"] {
+background-color: #343a40!important;
+}
+
+#sidebar .list-group .list-group-item[aria-expanded="true"]::after {
+content: " \f0da";
+font-family: FontAwesome;
+display: inline;
+text-align: right;
+padding-left: 5px;
+}
+
+/* level 1*/
+#sidebar .list-group .collapse .list-group-item,
+#sidebar .list-group .collapsing .list-group-item  {
+padding-left: 20px;
+}
+
+
+@media (max-width:768px) {
+  #sidebar {
+      min-width: 35px;
+      max-width: 40px;
+      overflow-y: auto;
+      overflow-x: visible;
+      transition: all 0.25s ease;
+      transform: translateX(-45px);
+      position: fixed;
+  }
+  .sidebar-icon{
+    display:block;
+  }
+  #sidebar.show {
+      transform: translateX(0);
+  }
+
+  #sidebar::-webkit-scrollbar{ width: 0px; }
+  
+  #sidebar, #sidebar .list-group {
+      min-width: 35px;
+      overflow: visible;
+  }
+  /* overlay sub levels on small screens */
+  #sidebar .list-group .collapse.show, #sidebar .list-group .collapsing {
+      position: relative;
+      z-index: 1;
+      width: 190px;
+      top: 0;
+  }
+  #sidebar .list-group > .list-group-item {
+      text-align: center;
+      padding: .75rem .5rem;
+  }
+  /* hide caret icons of top level when collapsed */
+  #sidebar .list-group > .list-group-item[aria-expanded="true"]::after,
+  #sidebar .list-group > .list-group-item[aria-expanded="false"]::after {
+      display:none;
+  }
+}
+
+.collapse.show {
+visibility: visible;
+}
+.collapsing {
+visibility: visible;
+height: 0;
+-webkit-transition-property: height, visibility;
+transition-property: height, visibility;
+-webkit-transition-timing-function: ease-out;
+transition-timing-function: ease-out;
+}
+.collapsing.width {
+-webkit-transition-property: width, visibility;
+transition-property: width, visibility;
+width: 0;
+height: 100%;
+-webkit-transition-timing-function: ease-out;
+transition-timing-function: ease-out;
+}


### PR DESCRIPTION
Created a view on the frontend for the different Order Statuses to be displayed. It's a Bootstrap Sidebar that utilizes the Tabs component to render different tables depending on what Tab is selected.

Requested Screen:
<img width="1206" alt="Screen Shot 2019-07-19 at 4 27 13 PM" src="https://user-images.githubusercontent.com/1075072/61570600-ad166400-aa42-11e9-8ac0-6b3a00e479d1.png">

Loaned View:
<img width="1200" alt="Screen Shot 2019-07-19 at 4 27 19 PM" src="https://user-images.githubusercontent.com/1075072/61570602-aee02780-aa42-11e9-99ce-95feac94d6f0.png">

Lent View:
<img width="1204" alt="Screen Shot 2019-07-19 at 4 27 26 PM" src="https://user-images.githubusercontent.com/1075072/61570605-b273ae80-aa42-11e9-861d-7992ee134650.png">

![bitmoji](https://render.bitstrips.com/v2/cpanel/c0070b40-8c33-4e40-9d93-d880ca58c92d-f35a46c4-b1dd-4da0-a9de-3b0fa0f211ba-v1.png?transparent=1&palette=1&width=246)