### PR TITLE
Order Status populating

### DIFF
--- a/p2plending/frontend/src/app/App.js
+++ b/p2plending/frontend/src/app/App.js
@@ -14,7 +14,7 @@ import Logout from "../components/auth/Logout";
 import Settings from "./settings/Settings"
 import NotFound from "../components/NotFound";
 import ScrollToTop from "../components/ScrollToTop";
-import OrderStatus from "./profile/OrderStatus";
+import OrderStatus from "./orderstatus/OrderStatus";
 import ReqUser from "./auth/ReqUser";
 
 class App extends Component {

--- a/p2plending/frontend/src/app/App.js
+++ b/p2plending/frontend/src/app/App.js
@@ -33,8 +33,8 @@ class App extends Component {
               <Route exact path="/language/:languageID" component={LanguageResults} />
               <Route exact path="/titles/:titleID" exact component={TitleIndividual} />
               <Route exact path="/settings/profile" component={Settings} />
-              <Route exact path="/:username" component={ReqUser(OrderStatus)} />
-              <Route exact path="/:username/:tabName" component={ReqUser(OrderStatus)} />
+              <Route exact path="/order-status" component={ReqUser(OrderStatus)} />
+              <Route exact path="/order-status/:tabName" component={ReqUser(OrderStatus)} />
               <Route exact path="/about" component={About} />
               <Route exact path="/privacy" component={Privacy} />
               <Route exact path="/terms" component={Terms} />

--- a/p2plending/frontend/src/app/Header.js
+++ b/p2plending/frontend/src/app/Header.js
@@ -4,12 +4,11 @@ import LoginModal from "./auth/LoginModal";
 import SignupModal from "./auth/SignupModal";
 import * as localStorage from "../components/componentUtils/localStorage";
 import Tooltip from "rc-tooltip";
-import * as api from "./backendCalls";
 
-const OptionsToolTip = ({ user }) => (
+const OptionsToolTip = () => (
   <div className="tooltip-content">
     <div className="tooltip-item">
-      <Link className="text-secondary" to={`/${user.username}`} disabled={!user.username}>
+      <Link className="text-secondary" to={`/order-status`}>
         Order Status
       </Link>
     </div>
@@ -57,7 +56,6 @@ class Header extends Component {
     // If CSRF Token is in Local Storage then request user name/profile info
     // If both are present then you can display User Information Instead of Login/Signup Button
     const authenticated = localStorage.getAuthKey();
-    const user = authenticated ? api.getUserName() : {};
 
     return (
       <div className="header">
@@ -81,7 +79,7 @@ class Header extends Component {
                     <Tooltip
                       placement="bottomRight"
                       trigger={["click"]}
-                      overlay={<OptionsToolTip user={user} />}
+                      overlay={<OptionsToolTip />}
                       id="header-logout"
                     >
                       <div className="position-relative">
@@ -111,7 +109,8 @@ class Header extends Component {
                       <small className="font-weight-bold">SIGN UP</small>
                     </button>
                   </li>,
-                ]}
+                ]
+            }
           </ul>
         </div>
       </div>

--- a/p2plending/frontend/src/app/auth/ReqUser.js
+++ b/p2plending/frontend/src/app/auth/ReqUser.js
@@ -12,24 +12,20 @@ const ReqUser = ComposedComponent => {
 
       if(this.state.user != {}) {
         // eslint-disable-next-line react/prop-types
-        const { username } = this.props.match.params;
-        if (username) {
-          this.fetchUserProfile(username);
-        }
+          this.fetchUserProfile();
       }
     }
 
-    fetchUserProfile = username => {
+    fetchUserProfile = () => {
       this.setState({ isLoading: true });
       api
-        .fetchUserProfile(username)
+        .fetchUserProfile()
         .then(({ data }) => this.setState({ user: data, isLoading: false }))
         .catch(() => this.setState({ isError: true, isLoading: false }));
     };
 
     render() {
       const { user, isLoading, isError } = this.state;
-
       if (isLoading) {
         return (
           <div className="container my-5">

--- a/p2plending/frontend/src/app/auth/ReqUser.js
+++ b/p2plending/frontend/src/app/auth/ReqUser.js
@@ -25,7 +25,6 @@ const ReqUser = ComposedComponent => {
         .fetchUserProfile(username)
         .then(({ data }) => this.setState({ user: data, isLoading: false }))
         .catch(() => this.setState({ isError: true, isLoading: false }));
-
     };
 
     render() {

--- a/p2plending/frontend/src/app/backendCalls.js
+++ b/p2plending/frontend/src/app/backendCalls.js
@@ -62,22 +62,14 @@ export const fetchRequestInfo = () => {
     return axios.get(`/api/v1/current/requests/`);
 }
 
-export const fetchUserProfile = ( username ) => {
-    console.log("backend call to get Profile Data")
+export const fetchUserProfile = () => {
     return axios.get(`/api/v1/current/profile/`);
 }
 
-export const getUserName = () => {
-    const user = {
-      username : "admin"
-    }
-    return user;
-};
-
 export const deleteUserProfile = () => {
-    console.log("delete User Profile from database");
+    console.log("TODO:: delete User Profile from database");
 };
 export const updateUserProfile = (profile) => {
-    console.log("backend call update User Data");
+    console.log("TODO:: backend call update User Data");
     console.log(profile);
 };

--- a/p2plending/frontend/src/app/backendCalls.js
+++ b/p2plending/frontend/src/app/backendCalls.js
@@ -50,12 +50,24 @@ export const submitLogin = (username,password,csrf) => {
     );
 }
 
+export const fetchBorrowingInfo = () => {
+    return axios.get(`/api/v1/current/borrowing/`);
+}
+
+export const fetchLendingInfo = () => {
+    return axios.get(`/api/v1/current/lending/`);
+}
+
+export const fetchRequestInfo = () => {
+    return axios.get(`/api/v1/current/requests/`);
+}
+
 export const fetchUserProfile = ( username ) => {
+    console.log("backend call to get Profile Data")
     return axios.get(`/api/v1/current/profile/`);
 }
 
 export const getUserName = () => {
-    console.log("backend call to get User Data")
     const user = {
       username : "admin"
     }

--- a/p2plending/frontend/src/app/orderstatus/OrderStatus.js
+++ b/p2plending/frontend/src/app/orderstatus/OrderStatus.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-console */
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-import LentSection from "./LentSection";
-import LoansSection from "./LoansSection";
-import RequestsSection from "./RequestsSection";
+import LentSection from "../profile/LentSection";
+import LoansSection from "../profile/LoansSection";
+import RequestsSection from "../profile/RequestsSection";
 import { Redirect } from "react-router-dom";
 import Tab from "../../components/Tab";
 
@@ -48,9 +48,6 @@ class OrderStatus extends Component {
   render() {
     const { user } = this.props;
     const { activeTab, isRedirect } = this.state;
-
-    console.log("User Props in Order Status")
-    console.log(user)
 
     if (isRedirect) {
       return <Redirect to="/" />;

--- a/p2plending/frontend/src/app/orderstatus/OrderStatus.js
+++ b/p2plending/frontend/src/app/orderstatus/OrderStatus.js
@@ -38,8 +38,7 @@ class OrderStatus extends Component {
   }
 
   onTabSelect = value => {
-    const { username } = this.props.match.params;
-    this.props.history.push(`/${username}/${value}`);
+    this.props.history.push(`/order-status/${value}`);
     this.setState({ activeTab: value });
   };
   

--- a/p2plending/frontend/src/app/orderstatus/StatusCard.js
+++ b/p2plending/frontend/src/app/orderstatus/StatusCard.js
@@ -1,0 +1,104 @@
+import React, { Component } from "react";
+import { Link } from "react-router-dom";
+import { getFlagEmoji } from "../../components/componentUtils/getFlag";
+
+const flagStyle = {
+  border: "1px solid lightgray", 
+  objectFit: 'none'}
+
+class StatusCard extends Component {
+
+  render() {
+    // eslint-disable-next-line react/prop-types
+    const { title, status, due_date, start_date } = this.props;
+    const status_regex = status.replace(/-/g, ' ');
+    // format due_date into a useable format
+    let due_date_mod;
+
+    if (due_date) {
+      const end_date = new Date(due_date);
+      if(start_date) {
+        const begin_date = new Date(start_date);
+        // const days_left = begin_date - end_date;
+        const days_left = Math.round((end_date - begin_date)/(1000*60*60*24));
+        if(days_left > 7) {
+          due_date_mod = <span className="text-success my-2" > {days_left} Days Left </span>
+        }
+        else if (days_left > 3 && days_left < 7) {
+          due_date_mod = <span className="text-warning my-2" > {days_left} Days Left </span>
+        }
+        else {
+          due_date_mod = <span className="text-danger my-2" > {days_left} Days Left </span>
+        }
+      }
+
+    }
+    else{
+      due_date_mod = <div></div>
+    }
+
+    return (
+      <div className="title-item col-12 col-sm-6 col-md-4 col-lg-3 d-flex mb-3" style={{height: 250}}>
+        <Link
+          className="item-link bg-white text-center rounded w-100 d-flex flex-column p-3 position-relative"
+          to={`/titles/${title.id}`}
+        >
+          {title.description ?
+            <div className="order-status-state"> 
+              <span className="text-primary my-2 order-status-status" id={ status } > 
+                { status_regex }
+              </span>
+              <div>
+                  { due_date_mod }
+              </div>
+            </div>
+            :(
+            <span className="text-secondary my-2">No State Found</span>
+          )}
+
+          <div className="title-image mb-2" >
+            {title.cover_image ? 
+              <img src={title.cover_image} />
+            :(
+              <span role="img" aria-label="emoji" style={{fontSize: 50}}>
+                📖
+              </span>
+            )}
+          </div>
+
+          <h6 className="font-weight-medium text-dark m-1">{title.title}</h6>
+          {title.author ? 
+            <h6 className="font-weight-medium text-secondary m-1">{title.author}, {title.publish_year}</h6>
+              :(
+            <h6 className="font-weight-medium text-secondary m-1"></h6>
+          )}
+          {title.language && (
+            <div
+              className="position-absolute d-flex align-items-center"
+              style={{ bottom: "15px", right: "18px" }}
+            >
+              <img alt="" height="20" width="30" className="ml-1 p-1" style={flagStyle} src={getFlagEmoji(title.language, 'flat/32')} />
+            </div>
+          )}
+          <div
+            className="position-absolute d-flex align-items-center"
+            style={{ bottom: "16px", left: "18px" }}
+          >
+            <div className="badge badge-secondary ml-1 p-0">
+              {title.media_type === "book" && (
+                <div className="text-uppercase p-1"> 📗{title.media_type}</div>
+              )}
+              {title.media_type === "periodical" && (
+                <div className="text-uppercase p-1"> 🗞️{title.media_type}</div>
+              )}
+            </div>
+          </div>
+
+        </Link>
+      </div>
+    );
+  }
+}
+
+
+export default StatusCard;

--- a/p2plending/frontend/src/app/profile/LentSection.js
+++ b/p2plending/frontend/src/app/profile/LentSection.js
@@ -2,10 +2,15 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import RegisterLenderModal from "../auth/RegisterLenderModal";
+import * as api from "../backendCalls";
+import StatusCard from "../orderstatus/StatusCard";
 
 class LentSection extends Component {
   state = {
     showRegisterLenderModal: false,
+    lent_items: [], 
+    isLoading: false, 
+    isError: false 
   };
 
   onOpenRegisterLenderModal = () => this.setState({ showRegisterLenderModal: true });
@@ -14,10 +19,22 @@ class LentSection extends Component {
     this.setState({ showRegisterLenderModal: false });
   };
 
+  componentDidMount() {
+      this.fetchLendingInfo();
+  }
+
+  fetchLendingInfo = () => {
+    this.setState({ isLoading: true });
+    api
+      .fetchLendingInfo()
+      .then(({ data }) => this.setState({ lent_items: data, isLoading: false }))
+      .catch(() => this.setState({ isError: true, isLoading: false }));
+  };
+
   render() {
-    const { lender_items, is_lender } = this.props;
-    console.log(lender_items)
-    
+    const { is_lender } = this.props;
+    const { lent_items, isLoading } = this.state;
+
     return (
       <div>
         <RegisterLenderModal isOpen={this.state.showRegisterLenderModal} onClose={this.onCloseRegisterLenderModal} />
@@ -46,8 +63,37 @@ class LentSection extends Component {
                   </div>
                 </div>
               )}
-
-              {/* Actual Content Goes Here */}
+              {is_lender && (
+                <div>
+                  {isLoading === false && (
+                    <div>
+                      {lent_items
+                        ? [
+                            <div className="container container--full px-4 my-5" key={1}>
+                              <div className="row">
+                                {lent_items.map(item => (
+                                  <StatusCard key={item.title.id} title={item.title} status={item.status} due_date={item.due_date} start_date={item.start_date} />
+                                ))}
+                              </div>
+                            </div>,
+                          ]
+                        : [
+                          <div className="container my-5" key={1}>
+                            You currently have no lent items.
+                          </div>,
+                      ]}
+                    </div>
+                  )}
+                  {isLoading && (
+                    <div>
+                      <div className="container my-5" key={1}>
+                        <i className="fas fa-spinner fa-spin mr-1" />
+                        Loading Loans...
+                      </div>
+                    </div>
+                  )}    
+                </div>
+              )}   
 
             </div>
           </div>

--- a/p2plending/frontend/src/app/profile/LoansSection.js
+++ b/p2plending/frontend/src/app/profile/LoansSection.js
@@ -1,11 +1,31 @@
 /* eslint-disable no-console */
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-
+import * as api from "../backendCalls";
+import StatusCard from "../orderstatus/StatusCard";
 
 class LoansSection extends Component {
 
+  state = { 
+    loans: [], 
+    isLoading: false, 
+    isError: false 
+  };
+
+  componentDidMount() {
+      this.fetchBorrowingInfo();
+  }
+
+  fetchBorrowingInfo = () => {
+    this.setState({ isLoading: true });
+    api
+      .fetchBorrowingInfo()
+      .then(({ data }) => this.setState({ loans: data, isLoading: false }))
+      .catch(() => this.setState({ isError: true, isLoading: false }));
+  };
+
   render() {
+    const { loans, isLoading } = this.state;
 
     return (
       <div>
@@ -17,8 +37,33 @@ class LoansSection extends Component {
         <div className="row">
           <div className="col-lg-12">
             <div className="m-1 w-100 h-100" style={{ background: "#f9f9f9", border: "1px solid #e8e8e8" }}>
-              Books that have gone from the requests to actually loaned out to the user will go here. 
-              {/* Actual Content Goes Here */}
+              {isLoading === false && (
+                <div>
+                  {loans
+                    ? [
+                        <div className="container container--full px-4 my-5" key={1}>
+                          <div className="row">
+                            {loans.map(item => (
+                              <StatusCard key={item.title.id} title={item.title} status={item.status} due_date={item.due_date} start_date={item.start_date} />
+                            ))}
+                          </div>
+                        </div>,
+                      ]
+                    : [
+                      <div className="container my-5" key={1}>
+                        You currently have no loans
+                      </div>,
+                  ]}
+                </div>
+              )}
+              {isLoading && (
+                <div>
+                  <div className="container my-5" key={1}>
+                    <i className="fas fa-spinner fa-spin mr-1" />
+                    Loading Loans...
+                  </div>
+                </div>
+              )}    
             </div>
           </div>
         </div>

--- a/p2plending/frontend/src/app/profile/RequestsSection.js
+++ b/p2plending/frontend/src/app/profile/RequestsSection.js
@@ -1,11 +1,31 @@
 /* eslint-disable no-console */
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-
+import * as api from "../backendCalls";
+import StatusCard from "../orderstatus/StatusCard";
 
 class RequestSection extends Component {
 
-  render() {
+  state = { 
+    requests: [], 
+    isLoading: false, 
+    isError: false 
+  };
+
+  componentDidMount() {
+      this.fetchRequestInfo();
+  }
+
+  fetchRequestInfo = () => {
+    this.setState({ isLoading: true });
+    api
+      .fetchRequestInfo()
+      .then(({ data }) => this.setState({ requests: data, isLoading: false }))
+      .catch(() => this.setState({ isError: true, isLoading: false }));
+  };
+
+  render(){
+    const { requests, isLoading } = this.state;
 
     return (
       <div>
@@ -17,8 +37,33 @@ class RequestSection extends Component {
         <div className="row">
           <div className="col-lg-12">
             <div className="m-1 w-100 h-100" style={{ background: "#f9f9f9", border: "1px solid #e8e8e8" }}>
-              Whenever a user &quot;requests&quot; a book, those requests will land here until they are ready for pickup/have been picked up
-              {/* Actual Content Goes Here */}
+            {isLoading === false && (
+                <div>
+                  {requests
+                    ? [
+                        <div className="container container--full px-4 my-5" key={1}>
+                          <div className="row">
+                            {requests.map(item => (
+                              <StatusCard key={item.title.id} title={item.title} status={item.status} due_date={item.due_date} start_date={item.start_date} />
+                            ))}
+                          </div>
+                        </div>,
+                      ]
+                    : [
+                      <div className="container my-5" key={1}>
+                        You currently have no loans
+                      </div>,
+                  ]}
+                </div>
+              )}
+              {isLoading && (
+                <div>
+                  <div className="container my-5" key={1}>
+                    <i className="fas fa-spinner fa-spin mr-1" />
+                    Loading Requests...
+                  </div>
+                </div>
+              )}  
             </div>
           </div>
         </div>

--- a/p2plending/frontend/src/app/titles/TitleIndividual.js
+++ b/p2plending/frontend/src/app/titles/TitleIndividual.js
@@ -166,7 +166,7 @@ class TitleIndividual extends Component {
                 className="position-absolute d-flex align-items-center"
                 style={{ bottom: "15px", right: "18px" }}
               >
-                <img alt="" height="20" width="32" ml-1 p-1 style={flagStyle} src={getFlagEmoji(title.language, 'flat/32')} />
+                <img alt="" height="20" width="32" className="ml-1 p-1" style={flagStyle} src={getFlagEmoji(title.language, 'flat/32')} />
               </div>
             )}
           </div>    

--- a/p2plending/frontend/src/app/titles/TitleItem.js
+++ b/p2plending/frontend/src/app/titles/TitleItem.js
@@ -41,7 +41,7 @@ const TitleItem = ({ title }) => (
           className="position-absolute d-flex align-items-center"
           style={{ bottom: "15px", right: "18px" }}
         >
-            <img alt="" height="20" width="30" ml-1 p-1 style={flagStyle} src={getFlagEmoji(title.language, 'flat/32')} />
+            <img alt="" height="20" width="30" className="ml-1 p-1" style={flagStyle} src={getFlagEmoji(title.language, 'flat/32')} />
         </div>
       )}
       <div

--- a/p2plending/frontend/src/index.css
+++ b/p2plending/frontend/src/index.css
@@ -140,8 +140,17 @@ h1 {
   width: 400px;
 }
 
+.order-status-state{
+  position: absolute;
+  top: 10px;
+}
+.order-status-status{
+  text-transform: uppercase;
+  font-weight: 500;
+}
 .title-item {
   height: 350px;
+  min-width: 250px;
 }
 
 .title-item .item-link {


### PR DESCRIPTION
This pull request tackles Issues #59 and #60

Created UI views for looking at users Loaned and Requested items.

Requested Items:
![Screen Shot 2019-08-22 at 9 15 12 AM](https://user-images.githubusercontent.com/1075072/63554703-55b95700-c50c-11e9-8a43-cd3f862b4da8.png)


Loaned Items:
![Screen Shot 2019-08-22 at 12 06 16 AM](https://user-images.githubusercontent.com/1075072/63554638-27d41280-c50c-11e9-9113-128244f3212f.png)


Also got rid of the /:username URL format in replace for a more manageable static /order-status URL format.

![image](https://user-images.githubusercontent.com/1075072/63554901-ff004d00-c50c-11e9-84b7-a8cee513b602.png)
